### PR TITLE
Fix input validation bug in tree functions

### DIFF
--- a/networkx_algo_common_subtree/tree_embedding.py
+++ b/networkx_algo_common_subtree/tree_embedding.py
@@ -147,7 +147,7 @@ def maximum_common_ordered_subtree_embedding(
             "only implemented for directed ordered trees. "
             "Got {} instead".format(type(tree1))
         )
-    if not isinstance(tree1, OrderedDiGraph):
+    if not isinstance(tree2, OrderedDiGraph):
         raise nx.NetworkXNotImplemented(
             "only implemented for directed ordered trees. "
             "Got {} instead".format(type(tree2))

--- a/networkx_algo_common_subtree/tree_isomorphism.py
+++ b/networkx_algo_common_subtree/tree_isomorphism.py
@@ -64,7 +64,7 @@ def maximum_common_ordered_subtree_isomorphism(
     # Note: checks that inputs are forests are handled by tree_to_seq
     if not isinstance(tree1, OrderedDiGraph):
         raise nx.NetworkXNotImplemented("only implemented for directed ordered trees")
-    if not isinstance(tree1, OrderedDiGraph):
+    if not isinstance(tree2, OrderedDiGraph):
         raise nx.NetworkXNotImplemented("only implemented for directed ordered trees")
 
     if tree1.number_of_nodes() == 0 or tree2.number_of_nodes() == 0:

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,19 @@
+import networkx as nx
+import pytest
+from networkx_algo_common_subtree.tree_embedding import maximum_common_ordered_subtree_embedding
+from networkx_algo_common_subtree.tree_isomorphism import maximum_common_ordered_subtree_isomorphism
+from networkx_algo_common_subtree._types import OrderedDiGraph
+
+
+def test_invalid_type_tree2_embedding():
+    tree1 = OrderedDiGraph([(0, 1)])
+    tree2 = nx.Graph([(0, 1)])  # not a directed ordered graph
+    with pytest.raises(nx.NetworkXNotImplemented):
+        maximum_common_ordered_subtree_embedding(tree1, tree2)
+
+
+def test_invalid_type_tree2_isomorphism():
+    tree1 = OrderedDiGraph([(0, 1)])
+    tree2 = nx.Graph([(0, 1)])  # not a directed ordered graph
+    with pytest.raises(nx.NetworkXNotImplemented):
+        maximum_common_ordered_subtree_isomorphism(tree1, tree2)


### PR DESCRIPTION
## Summary
- validate second tree argument in `maximum_common_ordered_subtree_embedding`
- validate second tree argument in `maximum_common_ordered_subtree_isomorphism`
- add tests covering invalid input types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68892c88dbb0832db32050184b481932