### PR TITLE
Enable abi3 wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ function(cpu_cython_module cython_source module_name)
 
   target_compile_definitions(${module_name} PUBLIC
     "NPY_NO_DEPRECATED_API"
+    "Py_LIMITED_API=0x03080000"
+    "CYTHON_LIMITED_API=1"
     #"NPY_1_7_API_VERSION=0x00000007"
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,14 @@
 requires = [ "setuptools>=41.0.1", "scikit-build>=0.11.1", "ninja>=1.10.2", "cmake>=3.21.2", "cython>=0.29.24",]
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+# Build only once for the oldest supported CPython version.  Because the
+# extensions are compiled against the stable ``abi3`` interface, the
+# resulting wheel will work on all newer Python versions as well.
+build = "cp38-*"
 build-frontend = "build"
 # skip = "pp* *-musllinux_* *-win32"
 build-verbosity = 1
+environment = {CFLAGS = "-DPy_LIMITED_API=0x03080000 -DCYTHON_LIMITED_API=1"}
 #test-requires = [ "-r requirements/tests.txt",]
 test-command = "python {project}/run_tests.py"
 test-extras = ["tests-strict", "runtime-strict"]


### PR DESCRIPTION
## Summary
- build extension modules with the stable ABI
- configure cibuildwheel to build only the cp38 wheel and use `abi3`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError after failing to install dependencies)*
- `pip install -e .` *(fails: Could not fetch build dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6889552945e8832d929aeddd56f3dc16